### PR TITLE
fix a bug when set TorchMode

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraView.java
@@ -74,7 +74,7 @@ public class RCTCameraView extends ViewGroup {
                 _viewFinder.setFlashMode(this._flashMode);
             }
             if (-1 != this._torchMode) {
-                _viewFinder.setFlashMode(this._torchMode);
+                _viewFinder.setTorchMode(this._torchMode);
             }
             addView(_viewFinder);
         }


### PR DESCRIPTION
fix a bug that will result into set torchMode as Camera.constants.TorchMode.on initial but torch still in off status. the reson is that invoke the wrong method setFlashMode instead of setTorchMode. I see lots of people have met this issuse. :-)